### PR TITLE
Fix little compilation error

### DIFF
--- a/app/core/scene_saver.hpp
+++ b/app/core/scene_saver.hpp
@@ -20,6 +20,7 @@
 
 #include "forward.hpp"
 
+#include <QObject>
 #include <QDateTime>
 
 #include <functional>


### PR DESCRIPTION
Under Arch Linux and recently updated Qt5.4.1, the compilation failed and showed as below. After inspecting, changes are made, and the compilation succeeds.

```
...
In file included from core/scene_saver.cpp:18:0:
./core/scene_saver.hpp:49:3: error: expected class-name before ‘{’ token
   {
   ^
...
```
